### PR TITLE
Provide 'original' to deface override

### DIFF
--- a/app/overrides/spree/admin/shared/sub_menu/_configuration.rb
+++ b/app/overrides/spree/admin/shared/sub_menu/_configuration.rb
@@ -1,6 +1,7 @@
 Deface::Override.new(
   virtual_path:  "spree/admin/shared/sub_menu/_configuration",
   name: "add_taxjar_admin_menu_link",
+  original: 'ec3c21025fa1602151155f972e1ac31b4319a5c4',
   insert_bottom: "[data-hook='admin_configurations_sidebar_menu']",
   text: "<%= configurations_sidebar_menu_item 'Taxjar Settings', edit_admin_taxjar_settings_path if can? :manage, Spree::Config %>"
 )


### PR DESCRIPTION
So when the 'original' changes we have a hint that we should look to make sure things still work as we want them to

Probably shouldn't merge the PR in eComm until we put this one on master here. @elianderson WDYT?